### PR TITLE
Add pictures support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 *.swp
 *.swo
 .direnv
+
+# Project Stuff
+.porscheconnect.cfg

--- a/pyporscheconnectapi/cli.py
+++ b/pyporscheconnectapi/cli.py
@@ -64,6 +64,8 @@ async def main(args):
                         data = await client.getCurrentOverview(vin)
                 elif args.command == "capabilities":
                     data = await client.getCapabilities(vin)
+                elif args.command == "pictures":
+                    data = await client.getPictures(vin, size=args.size)
                 print(json.dumps(data, indent=2))
 
     except WrongCredentials as e:
@@ -84,6 +86,10 @@ def add_arg_vin(parser):
 
 def add_arg_model(parser):
     parser.add_argument("-m", "--model", dest="model", default=None)
+
+
+def add_arg_size(parser):
+    parser.add_argument("-s", "--size", dest="size", default=2)
 
 
 def cli():
@@ -120,6 +126,10 @@ def cli():
 
     parser_command_overview = subparsers.add_parser("overview")
     add_arg_vin(parser_command_overview)
+
+    parser_command_pictures = subparsers.add_parser("pictures")
+    add_arg_vin(parser_command_pictures)
+    add_arg_size(parser_command_pictures)
 
     args = parser.parse_args()
 

--- a/pyporscheconnectapi/client.py
+++ b/pyporscheconnectapi/client.py
@@ -59,3 +59,9 @@ class Client:
             f"https://api.ppa.porsche.com/app/connect/v1/vehicles/{vin}?{measurements+wakeup}"
         )
         return data
+
+    async def getPictures(self, vin, size=2):
+        data = await self._connection.get(
+            f"https://api.ppa.porsche.com/app/connect/v1/vehicles/{vin}/pictures?size={size}"
+        )
+        return data


### PR DESCRIPTION
Hi,

Submitting a small change to grab the pictures for the vehicle.

Response has this shape:

```json
[
    {
        "view": "frontView",
        "url": "https://picserv.porsche.com/picserv/images-api/v4/f8034063cb10a9fca911c7a72dcc151a/2",
        "size": 2
    },
    {
        "view": "sideView",
        "url": "https://picserv.porsche.com/picserv/images-api/v4/f7ce3b50e9ba032b8fa21a297c124fdf/2",
        "size": 2
    },
    {
        "view": "rearView",
        "url": "https://picserv.porsche.com/picserv/images-api/v4/71fde0d617f99fa54a3ffbf47ed5da9d/2",
        "size": 2
    },
    {
        "view": "rearTopView",
        "url": "https://picserv.porsche.com/picserv/images-api/v4/686340126c9786db257c255c6a8669c4/2",
        "size": 2
    },
    {
        "view": "topView",
        "url": "https://picserv.porsche.com/picserv/images-api/v4/121bfa11389fd5431f61d7d63af07ca3/2",
        "size": 2
    }
]
```

Size seems to range from 1-5 but, at least for my Taycan, some of those sizes return an empty set (I only get 1, 2, and 5 even with a `200` status back).

I also added an option to CLI to grab them.