### PR TITLE
Move to HTTPX and refactor OAuth2 logic

### DIFF
--- a/pyporscheconnectapi/client.py
+++ b/pyporscheconnectapi/client.py
@@ -2,8 +2,6 @@ from pyporscheconnectapi.connection import Connection
 from pyporscheconnectapi.exceptions import WrongCredentials
 from hashlib import sha512
 
-import asyncio
-import datetime
 import logging
 import uuid
 
@@ -26,7 +24,7 @@ class Client:
 
     async def getVehicles(self):
         vehicles = await self._connection.get(
-            f"https://api.ppa.porsche.com/app/connect/v1/vehicles"
+            f"/connect/v1/vehicles"
         )
         return vehicles
 
@@ -35,7 +33,7 @@ class Client:
         commands = "&cf=" + "&cf=".join(COMMANDS)
 
         data = await self._connection.get(
-            f"https://api.ppa.porsche.com/app/connect/v1/vehicles/{vin}?{measurements+commands}"
+            f"/connect/v1/vehicles/{vin}?{measurements+commands}"
         )
         return data
 
@@ -43,7 +41,7 @@ class Client:
         measurements = "mf=" + "&mf=".join(MEASUREMENTS)
 
         data = await self._connection.get(
-            f"https://api.ppa.porsche.com/app/connect/v1/vehicles/{vin}?{measurements}"
+            f"/connect/v1/vehicles/{vin}?{measurements}"
         )
         return data
 
@@ -53,7 +51,7 @@ class Client:
         wakeup = "&wakeUpJob=" + id
 
         data = await self._connection.get(
-            f"https://api.ppa.porsche.com/app/connect/v1/vehicles/{vin}?{measurements+wakeup}"
+            f"/connect/v1/vehicles/{vin}?{measurements+wakeup}"
         )
         return data
 
@@ -92,12 +90,13 @@ class Client:
             "key": "CHARGING_PROFILES_EDIT",
             "payload": {"list": chargingprofileslist},
         }
-        print(profile)
+        _LOGGER.debug(f"Updating charging profile for {vin}")
 
         result = await self._connection.post(
-            f"https://api.ppa.porsche.com/app/connect/v1/vehicles/{vin}/commands",
+            f"/connect/v1/vehicles/{vin}/commands",
             json=profile,
         )
 
-        print(result)
+        _LOGGER.debug(result)
+
         return result

--- a/pyporscheconnectapi/connection.py
+++ b/pyporscheconnectapi/connection.py
@@ -3,398 +3,105 @@
 Python Package for controlling Porsche Connect API.
 
 """
-import asyncio
-import calendar
-import datetime
-import json
 import logging
-import time
-import base64
-import os
-import urllib
-import uuid
+import asyncio
+from typing import Text
 
-from urllib.parse import urlunparse, urlencode
-from collections import namedtuple
-from typing import Dict, Text
-
-import aiohttp
-
+import httpx
+from .oauth2 import OAuth2Token, OAuth2Client, Credentials
 from .const import *
+
+from typing import Any, Dict
 
 try:
     from rich import print
 except ImportError:
     pass
 
-from .exceptions import CaptchaRequired, WrongCredentials, PorscheException
+from .exceptions import PorscheException
 
 _LOGGER = logging.getLogger(__name__)
 
-
-async def on_request_start(session, trace_config_ctx, params):
-    _LOGGER.debug("Starting request")
-    _LOGGER.debug(params)
-
-
-async def on_request_end(session, trace_config_ctx, params):
-    _LOGGER.debug("Ending request")
-    _LOGGER.debug(params)
-
-
-trace_config = aiohttp.TraceConfig()
-trace_config.on_request_start.append(on_request_start)
-trace_config.on_request_end.append(on_request_end)
+async def log_request(request):
+    _LOGGER.debug(f"Request headers: {request.headers}")
+    _LOGGER.debug(f"Request method - url: {request.method} {request.url}")
+    _LOGGER.debug(f"Request body: {request.content}")
 
 
 class Connection:
-    """Connection to Porsche Connect API."""
+    """
+    Handles authentication and connecting to the Porsche Connect API
+
+    :param email: Porsche Connect email
+    :param password: Porsche Connect password
+    :param websession: httpx.AsyncClient or None
+    :param token: token dict - should be a dict with access_token, refresh_token, expires_at, etc as root params
+    :param leeway: time in seconds to consider token as expired before it actually expires
+    """
 
     def __init__(
         self,
         email: Text = None,
         password: Text = None,
-        websession: aiohttp.ClientSession = None,
-        x_client_id: Text = None,
+        websession: httpx.AsyncClient = None,
         token=None,
+        leeway: int = 60,
     ) -> None:
-        """Initialize connection object."""
-
-        self.token = token or None
-        self.email = email
-        self.password = password
-        self.x_client_id = "41843fb4-691d-4970-85c7-2673e8ecef40"
         self.websession = websession
-        self._isLoggedIn = False
-        self.auth_state = {}
+        self.token_lock = asyncio.Lock()
+
+        self.token = OAuth2Token(token)
 
         if self.websession is None:
-            self.websession = aiohttp.ClientSession(trace_configs=[trace_config])
-        _LOGGER.debug("New connection prepared")
-
-    async def _login(self):
-        Components = namedtuple(
-            typename="Components",
-            field_names=["scheme", "netloc", "url", "params", "query", "fragment"],
-        )
-
-        # 1. Get initial state
-
-        _LOGGER.debug("Start authentication, get initial state from auth server")
-
-        query_params = {
-            "response_type": "code",
-            "client_id": CLIENT_ID,
-            "redirect_uri": REDIRECT_URI,
-            "audience": AUDIENCE,
-            "scope": SCOPE,
-        }
-
-        headers = {
-            "User-Agent": USER_AGENT,
-        }
-
-        url = urlunparse(
-            Components(
-                scheme="https",
-                netloc=AUTHORIZATION_SERVER,
-                url="/authorize",
-                params="",
-                query=urlencode(query_params),
-                fragment="",
+            self.websession = httpx.AsyncClient(
+                base_url=API_BASE_URL,
+                headers={"User-Agent": USER_AGENT, "X-Client-ID": CLIENT_ID},
+                event_hooks={"request": [log_request]},
+                verify=False
             )
-        )
-
-        async with self.websession.get(
-            url, headers=headers, allow_redirects=False
-        ) as resp:
-            location = resp.headers["Location"]
-            params = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
-            have_code = params.get("code", None)
-
-            if have_code is not None:
-                _LOGGER.debug("We already have a code in session, skip login")
-                self.auth_state["code"] = have_code
-                return
-
-            self.auth_state["state"] = params["state"][0]
-        _LOGGER.debug(self.auth_state)
-
-        # 2. Post username
-
-        _LOGGER.debug("POST username")
-
-        query_params = {
-            "state": self.auth_state["state"],
-        }
-
-        url = urlunparse(
-            Components(
-                scheme="https",
-                netloc=AUTHORIZATION_SERVER,
-                url="/u/login/identifier",
-                params="",
-                query=urlencode(query_params),
-                fragment="",
+        elif isinstance(self.websession, httpx.AsyncClient):
+            self.websession.base_url = API_BASE_URL
+            self.websession.headers.update(
+                {"User-Agent": USER_AGENT, "X-Client-ID": CLIENT_ID}
             )
-        )
+            self.websession.event_hooks["request"] = [log_request]
+        else:
+            raise TypeError("websession must be an instance of httpx.AsyncClient")
 
-        headers = {
-            "User-Agent": USER_AGENT,
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        auth_body = {
-            "state": self.auth_state["state"],
-            "username": self.email,
-            "js-available": True,
-            "webauthn-available": False,
-            "is-brave": False,
-            "webauthn-platform-available": False,
-            "action": "default",
-        }
-
-        async with self.websession.post(
-            url,
-            headers=headers,
-            data=auth_body,
-            max_redirects=30,
-        ) as resp:
-
-            # In case of wrong credentials there is a state param in the redirect url
-            if resp.status == 401:
-                message = await resp.json()
-                raise WrongCredentials(
-                    message.get("message", message.get("description", "Unknown error"))
-                )
-
-            # In case captcha verification is required, the response code is 400 and the captcha is provided as a svg image
-            if resp.status == 400:
-                html_body = await resp.text()
-                raise CaptchaRequired("Captcha required")
-
-            _LOGGER.debug(resp)
-
-        # 3. Post password
-
-        _LOGGER.debug("POST password")
-
-        query_params = {
-            "state": self.auth_state["state"],
-        }
-
-        url = urlunparse(
-            Components(
-                scheme="https",
-                netloc=AUTHORIZATION_SERVER,
-                url="/u/login/password",
-                params="",
-                query=urlencode(query_params),
-                fragment="",
-            )
-        )
-
-        auth_body = {
-            "state": self.auth_state["state"],
-            "username": self.email,
-            "password": self.password,
-            "action": "default",
-        }
-
-        async with self.websession.post(
-            url,
-            headers=headers,
-            data=auth_body,
-            allow_redirects=False,
-        ) as resp:
-
-            # In case of wrong credentials there is a state param in the redirect url
-            if resp.status == 401:
-                message = await resp.json()
-                raise WrongCredentials(
-                    message.get("message", message.get("description", "Unknown error"))
-                )
-
-            _LOGGER.debug(resp)
-
-            resume_url = resp.headers["Location"]
-            _LOGGER.debug(f"Resume at {resume_url}")
-
-        _LOGGER.debug("Sleeping 2.5s...")
-        await asyncio.sleep(2.5)
-
-        # 4. Resume auth to get authorization code
-
-        url = urlunparse(
-            Components(
-                scheme="https",
-                netloc=AUTHORIZATION_SERVER,
-                url=resume_url,
-                params="",
-                query="",
-                fragment="",
-            )
-        )
-
-        async with self.websession.get(url, allow_redirects=False) as resp:
-            location = resp.headers["Location"]
-            params = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
-            _LOGGER.debug(params)
-            self.auth_state["code"] = params["code"][0]
-            _LOGGER.debug(f"Got authorization code {self.auth_state['code']}")
-
-        _LOGGER.debug("Sleeping 2.5s...")
-        await asyncio.sleep(2.5)
-
-        self._isLoggedIn = True
-        return True
+        self.oauth2_client = OAuth2Client(self.websession, Credentials(email, password), leeway)
 
     async def getToken(self):
-        now = calendar.timegm(datetime.datetime.now().timetuple())
-        _LOGGER.debug(f"Get token")
-        token = self.token
-        if token is None:
-            token = await self._requestToken()
-            self.token = token
-
-        if token["expiration"] < now:
-            token = await self._refreshToken()
-            self.token = token
-
+        async with self.token_lock:
+            await self.oauth2_client.ensure_valid_token(self.token)
         return self.token
 
-    async def _requestToken(self):
-        if not self._isLoggedIn:
-            await self._login()
-
-        _LOGGER.debug("POST to access token endpoint:")
-        auth_url = f"https://{AUTHORIZATION_SERVER}/oauth/token"
-        auth_body = {
-            "client_id": CLIENT_ID,
-            "grant_type": "authorization_code",
-            "code": self.auth_state["code"],
-            "redirect_uri": REDIRECT_URI,
-        }
-        _LOGGER.debug(auth_body)
-        _LOGGER.debug("Requesting access token for client id %s", CLIENT_ID)
-        now = calendar.timegm(datetime.datetime.now().timetuple())
-        async with self.websession.post(
-            auth_url,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data=auth_body,
-            max_redirects=30,
-        ) as resp:
-            _LOGGER.debug(f"Response status {resp.status}")
-            token_data = await resp.json()
-            _LOGGER.debug(token_data)
-            jwt = self.jwt_payload_decode(token_data["access_token"])
-            token = token_data
-            token["expiration"] = now + token_data.get("exp", 3600)
-            token["decoded_token"] = jwt
-            token["apikey"] = jwt["azp"]
-            _LOGGER.debug("Token: %s", token)
-            return token
-
-    async def _refreshToken(self):
-        _LOGGER.debug("POST to refresh token endpoint:")
-        auth_url = f"https://{AUTHORIZATION_SERVER}/oauth/token"
-        auth_body = {
-            "client_id": CLIENT_ID,
-            "grant_type": "refresh_token",
-            "refresh_token": self.token["refresh_token"],
-        }
-        _LOGGER.debug(auth_body)
-        _LOGGER.debug(
-            "Requesting access token using refresh token for client id %s", CLIENT_ID
-        )
-        now = calendar.timegm(datetime.datetime.now().timetuple())
-        async with self.websession.post(
-            auth_url,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data=auth_body,
-            max_redirects=30,
-        ) as resp:
-            _LOGGER.debug(f"Response status {resp.status}")
-            if resp.status == 200:
-                _LOGGER.debug(f"Refresh ok")
-                token_data = await resp.json()
-                _LOGGER.debug(token_data)
-                jwt = self.jwt_payload_decode(token_data["access_token"])
-                token = token_data
-                token["expiration"] = now + token_data.get("exp", 3600)
-                token["decoded_token"] = jwt
-                token["apikey"] = jwt["azp"]
-                _LOGGER.debug("Token: %s", token)
-            else:
-                _LOGGER.debug(f"Refresh rejected, restarting authentication flow")
-                self._isLoggedIn = False
-                token = await self._requestToken()
-            return token
-
     async def get(self, url, params=None):
-        try:
-            headers = await self._createhead()
-            async with self.websession.get(url, params=params, headers=headers) as resp:
-                return await resp.json()
-        except aiohttp.ClientResponseError as exception_:
-            raise PorscheException(exception_.status)
+        return await self.request("GET", url, params=params)
 
     async def post(self, url, data=None, json=None):
-        try:
-            headers = await self._createhead()
-            async with self.websession.post(
-                url, data=data, json=json, headers=headers
-            ) as resp:
-                return await resp.json()
-        except aiohttp.ClientResponseError as exception_:
-            raise PorscheException(exception_.status)
+        return await self.request("POST", url, data=data, json=json)
 
     async def put(self, url, data=None, json=None):
-        try:
-            headers = await self._createhead()
-            async with self.websession.put(
-                url, data=data, json=json, headers=headers
-            ) as resp:
-                return await resp.json()
-        except aiohttp.ClientResponseError as exception_:
-            raise PorscheException(exception_.status)
+        return await self.request("PUT", url, data=data, json=json)
 
     async def delete(self, url, data=None, json=None):
+        return await self.request("DELETE", url, data=data, json=json)
+
+    async def request(self, method, url, **kwargs):
         try:
-            headers = await self._createhead()
-            async with self.websession.delete(
-                url, data=data, json=json, headers=headers
-            ) as resp:
-                return await resp.json()
-        except aiohttp.ClientResponseError as exception_:
-            raise PorscheException(exception_.status)
-
-    async def _createhead(self):
-        now = calendar.timegm(datetime.datetime.now().timetuple())
-        token = self.token
-        if token is None:
-            token = await self._requestToken()
-            self.token = token
-        if token["expiration"] < now:
-            token = await self._refreshToken()
-            self.token = token
-        xid = str(uuid.uuid4()).upper()
-        head = {
-            "Authorization": f"Bearer {token['access_token']}",
-            "X-Client-ID": self.x_client_id,
-            "User-Agent": USER_AGENT,
-            "X-Request-ID": xid,
-            "X-Trace-ID": xid,
-        }
-        return head
-
-    def _b64_decode(self, data):
-        data += "=" * (4 - len(data) % 4)
-        return base64.b64decode(data).decode("utf-8")
-
-    def jwt_payload_decode(self, jwt):
-        _, payload, _ = jwt.split(".")
-        return json.loads(self._b64_decode(payload))
+            async with self.token_lock:
+                await self.oauth2_client.ensure_valid_token(self.token)
+            resp = await self.websession.request(
+                method,
+                url,
+                headers={"Authorization": f"Bearer {self.token.access_token}"},
+                **kwargs,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as exception_:
+            raise PorscheException(exception_.response.status_code)
 
     async def close(self):
-        await self.websession.close()
+        """Close the websession connection"""
+        await self.websession.aclose()

--- a/pyporscheconnectapi/const.py
+++ b/pyporscheconnectapi/const.py
@@ -8,7 +8,9 @@ X_CLIENT_ID = "41843fb4-691d-4970-85c7-2673e8ecef40"
 USER_AGENT = "pyporscheconnectapi/0.2.0"
 # USER_AGENT = "de.porsche.one/11.24.14+301 (ios)"
 SCOPE = "openid profile email offline_access mbb ssodb badge vin dealers cars charging manageCharging plugAndCharge climatisation manageClimatisation pid:user_profile.porscheid:read pid:user_profile.name:read pid:user_profile.vehicles:read pid:user_profile.dealers:read pid:user_profile.emails:read pid:user_profile.phones:read pid:user_profile.addresses:read pid:user_profile.birthdate:read pid:user_profile.locale:read pid:user_profile.legal:read"
-
+API_BASE_URL = "https://api.ppa.porsche.com/app"
+AUTHORIZATION_URL = f"https://{AUTHORIZATION_SERVER}/authorize"
+TOKEN_URL = f"https://{AUTHORIZATION_SERVER}/oauth/token"
 
 """ Vehicle properties """
 

--- a/pyporscheconnectapi/oauth2.py
+++ b/pyporscheconnectapi/oauth2.py
@@ -1,0 +1,261 @@
+#  SPDX-License-Identifier: Apache-2.0
+import asyncio
+import logging
+import time
+import httpx
+
+from urllib.parse import urlparse, parse_qs
+from collections import namedtuple
+
+from typing import Dict, Text
+
+from .const import *
+from .exceptions import CaptchaRequired, WrongCredentials, PorscheException
+
+_LOGGER = logging.getLogger(__name__)
+
+Credentials = namedtuple("Credentials", ["email", "password"])
+
+class OAuth2Token(dict):
+    """
+    A simple wrapper around a dict to handle OAuth2 tokens. Provides a helper
+    method to check if the token is expired.
+
+    Originally based on: https://github.com/lepture/authlib/blob/master/authlib/oauth2/rfc6749/wrappers.py
+    """
+
+    def __init__(self, params: Dict):
+        if params.get("expires_at"):
+            self["expires_at"] = int(params["expires_at"])
+        elif params.get("expires_in"):
+            self.expires_at = params["expires_in"]
+        super().__init__(params)
+
+    def is_expired(self, leeway=60):
+        expires_at = self.get("expires_at")
+        if not expires_at:
+            return None
+        # small timedelta to consider token as expired before it actually expires
+        expiration_threshold = expires_at - leeway
+        return expiration_threshold < time.time()
+
+    @property
+    def expires_at(self):
+        return self.get("expires_at")
+
+    @property
+    def access_token(self):
+        return self.get("access_token")
+
+    @property
+    def refresh_token(self):
+        return self.get("refresh_token")
+
+    @expires_at.setter
+    def expires_at(self, expires_in):
+        self["expires_at"] = int(time.time()) + int(expires_in)
+
+
+class OAuth2Client:
+    """
+      Utility class to handle OAuth2 authentication with Porsche Connect
+      
+      :param client: httpx.AsyncClient
+      :param credentials: tuple of email, password
+      :param leeway: time in seconds to consider token as expired before it actually expires
+    """
+    def __init__(self, client: httpx.AsyncClient, credentials: Credentials, leeway: int = 60):
+        self.client = client
+        self.credentials = credentials
+        self.leeway = leeway
+
+    async def ensure_valid_token(self, token: OAuth2Token):
+        """
+        Ensure the access_token is valid, logging in or refreshing if necessary
+        """
+        token_is_expired = token.is_expired(self.leeway)
+        if token.access_token is None or token_is_expired is None:  # no token, get a new one
+            auth_code = await self.fetch_authorization_code()
+            token_data = await self.fetch_access_token(auth_code)
+            token.update(token_data)
+            token.expires_at = token_data["expires_in"]
+            _LOGGER.debug(f"New Access Token: {token.access_token}")
+        elif token_is_expired:
+            token_data = await self.refresh_token(token.refresh_token)
+            token.update(token_data)
+            token.expires_at = token_data["expires_in"]
+            _LOGGER.debug(f"Refreshed Access Token: {token.access_token}")
+
+    async def fetch_authorization_code(self):
+        """
+        Fetch the authorization code from Porsche Connect
+
+        Requires 1-4 requests (1 if already logged in, 4 if not):
+
+        1. Initial request to /authorize to get the code
+        2. If no code is returned, login with Identifier First flow:
+            2a. POST to /u/login/identifier with email
+            2b. POST to /u/login/password with password
+        3. Resume the /authorize request with the resume path from the Identifier First flow
+
+        :return: authorization code to be exchanged for an access token
+        """
+        try:
+            # first request to get the code
+            params = await self.get_and_extract_location_params(
+                AUTHORIZATION_URL,
+                params={
+                    "response_type": "code",
+                    "client_id": CLIENT_ID,
+                    "redirect_uri": REDIRECT_URI,
+                    "audience": AUDIENCE,
+                    "scope": SCOPE,
+                    "state": "pyporscheconnectapi",
+                },
+            )
+            authorization_code = params.get("code", [None])[0]
+
+            # if we already have a session with Auth, just use the code they return
+            if authorization_code is not None:
+                _LOGGER.debug(f"Authorization code: {authorization_code}")
+                return authorization_code
+
+            # no existing Auth0 session, run through Identifier First flow
+            resume_path = await self.login_with_identifier(params["state"][0])
+
+            # completed the Identifier First flow, now resume the auth code request
+            params = await self.get_and_extract_location_params(f"https://{AUTHORIZATION_SERVER}{resume_path}")
+            authorization_code = params.get("code", [None])[0]
+            _LOGGER.debug(f"Authorization code: {authorization_code}")
+
+            return authorization_code
+
+        except httpx.HTTPStatusError as exception_:
+            raise PorscheException(exception_.response.status_code)
+
+    async def get_and_extract_location_params(self, url, params={}):
+        """
+        GET the URL and extract the params from the Location header
+
+        :param url: URL to GET
+        :param params: dict of query parameters
+        :return: dict of query parameters from the Location header
+        """
+        resp = await self.client.get(url, params=params)
+        location = resp.headers["Location"]
+        return self._extract_params_from_url(location)
+
+    def _extract_params_from_url(self, url):
+        """
+        Extract the query parameters from a URL
+
+        :param url: URL to extract the query parameters from
+        :return: dict of query parameters
+        """
+        return parse_qs(urlparse(url).query)
+
+    async def login_with_identifier(self, state: Text):
+        """
+        Logs into the Identifier First flow
+
+        Takes 2 steps:
+
+        1. POST to /u/login/identifier with email
+        2. POST to /u/login/password with password
+
+        :param state: state parameter from the initial authorize request
+        :return: URL to resume the auth code request
+        """
+
+        # 1. /u/login/identifier w/ email
+        data = {
+            "state": state,
+            "username": self.credentials.email,
+            "js-available": True,
+            "webauthn-available": False,
+            "is-brave": False,
+            "webauthn-platform-available": False,
+            "action": "default",
+        }
+
+        url = f"https://{AUTHORIZATION_SERVER}/u/login/identifier"
+        resp = await self.client.post(url, data=data, params={"state": state})
+
+        if resp.status_code == 401:
+            message = resp.json()
+            raise WrongCredentials(
+                message.get("message", message.get("description", "Unknown error"))
+            )
+
+        # In case captcha verification is required, the response code is 400 and the captcha is provided as a svg image
+        if resp.status_code == 400:
+            html_body = resp.text()
+            _LOGGER.debug(html_body)
+            raise CaptchaRequired("Captcha required")
+
+        # 2. /u/login/password w/ password
+        data = {
+            "state": state,
+            "username": self.credentials.email,
+            "password": self.credentials.password,
+            "action": "default",
+        }
+
+        url = f"https://{AUTHORIZATION_SERVER}/u/login/password"
+        resp = await self.client.post(url, data=data, params={"state": state})
+
+        if resp.status_code == 401:
+            message = resp.json()
+            raise WrongCredentials(
+                message.get("message", message.get("description", "Unknown error"))
+            )
+
+        resume_url = resp.headers["Location"]
+        _LOGGER.debug(f"Resume at {resume_url}")
+
+        _LOGGER.debug("Sleeping 2.5s...")
+        await asyncio.sleep(2.5)
+
+        return resume_url
+
+    async def fetch_access_token(self, authorization_code):
+        """
+        Exchanges the authorization code for an access token
+
+        :param authorization_code: authorization code from the /authorize request
+        :return: access token
+        """
+        data = {
+            "client_id": CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": REDIRECT_URI,
+        }
+
+        try:
+            resp = await self.client.post(TOKEN_URL, data=data)
+            resp.raise_for_status()
+            token_data = resp.json()
+            return token_data
+        except httpx.HTTPStatusError as exception_:
+            raise PorscheException(exception_.response.status_code)
+
+    async def refresh_token(self, refresh_token):
+        """
+        Uses the provided refresh token to get a new access token
+
+        :param refresh_token: refresh token
+        :return: access token
+        """
+        data = {
+            "client_id": CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+        try:
+            resp = await self.client.post(TOKEN_URL, data=data)
+            resp.raise_for_status()
+            token_data = resp.json()
+            return token_data
+        except httpx.HTTPStatusError as exception_:
+            raise PorscheException(exception_.response.status_code)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,1 @@
-aiohttp
+httpx

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT",
     packages=["pyporscheconnectapi"],
     python_requires=">=3.6",
-    install_requires=["aiohttp<4"],
+    install_requires=["httpx<1"],
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",


### PR DESCRIPTION
Finally got some time to put together a PR for this:

- Moves from `aiohttp` to `httpx`. Note I did not use the context manager for this to allow for compatibility with injecting an `httpx` client from Home Assistant (see[ helper here](https://github.com/home-assistant/core/blob/86891351f65d37ec559de4ca5dda86e3494a9990/homeassistant/helpers/httpx_client.py#L54))
- Cleaned up and moved the OAuth2 logic into a standalone utility class. I tried a few different OAuth2 libraries (like `authlib` or `httpx-auth`) and they seemed to always be more trouble than they were worth (especially trying to automate the Auth0 Identifier First login pages)
- `Connection` will automatically manage the token, including the appropriate refresh logic (with leeway support)
- I removed some stuff that I didn't think was still needed (such as the locales and the JWT parsing)

One thing I haven't figured out yet: I had to turn off SSL verification in `httpx` because Porsche has some self-signed cert somewhere in their chain that causes `httpx` to fail verification. I'm assuming this is just a root cert issue in `httpx` (as Postman isn't having this issue)