### PR TITLE
Feature/50 rewrite cli

### DIFF
--- a/pyporscheconnectapi/cli.py
+++ b/pyporscheconnectapi/cli.py
@@ -65,11 +65,9 @@ async def main(args):
                 vehicle = await controller.get_vehicle(vin)
                 if vehicle is not None:
                     if args.command == "overview":
-                        await vehicle._update_data_for_vehicle(True)
-                        data = vehicle.data
+                        data = await vehicle.get_current_overview()
                     elif args.command == "storedoverview":
-                        await vehicle._update_data_for_vehicle(False)
-                        data = vehicle.data
+                        data = await vehicle.get_stored_overview()
                     elif args.command == "chargingprofile":
                         service = RemoteServices(vehicle)
                         data = await service.updateChargingProfile(
@@ -77,7 +75,7 @@ async def main(args):
                             minimumChargeLevel=args.minimumchargelevel,
                         )
                     elif args.command == "capabilities":
-                        data = await vehicle.capabilities()
+                        data = await vehicle.get_capabilities()
                     print(json.dumps(data, indent=2))
 
     except WrongCredentials as e:

--- a/pyporscheconnectapi/client.py
+++ b/pyporscheconnectapi/client.py
@@ -1,6 +1,8 @@
 from pyporscheconnectapi.connection import Connection
 from pyporscheconnectapi.exceptions import WrongCredentials
 from hashlib import sha512
+from typing import Optional
+
 
 import logging
 import uuid
@@ -13,17 +15,14 @@ _LOGGER = logging.getLogger(__name__)
 class Client:
     """Client for Porsche Connect API."""
 
-    def __init__(
-        self,
-        connection: Connection,
-    ) -> None:
+    def __init__(self, connection: Connection) -> None:
         self._connection = connection
 
     async def getToken(self):
         return await self._connection.getToken()
 
     async def getVehicles(self):
-        vehicles = await self._connection.get(f"/connect/v1/vehicles")
+        vehicles = await self._connection.get("/connect/v1/vehicles")
         return vehicles
 
     async def getCapabilities(self, vin):
@@ -51,47 +50,47 @@ class Client:
         )
         return data
 
-    async def updateChargingProfile(
-        self,
-        vin,
-        profileId: int,
-        minimumChargeLevel: int = None,
-    ):
-        measurements = (await self.getStoredOverview(vin))["measurements"]
-        chargingprofiles = (
-            [e for e in measurements if e["key"] == "CHARGING_PROFILES"]
-        )[0]["value"]
-        chargingprofileslist = chargingprofiles["list"]
+    # async def updateChargingProfile(
+    #     self,
+    #     vin,
+    #     profileId: int,
+    #     minimumChargeLevel: Optional[int] = None,
+    # ):
+    #     measurements = (await self.getStoredOverview(vin))["measurements"]
+    #     chargingprofiles = (
+    #         [e for e in measurements if e["key"] == "CHARGING_PROFILES"]
+    #     )[0]["value"]
+    #     chargingprofileslist = chargingprofiles["list"]
+    #
+    #     if profileId is None:
+    #         profileId = chargingprofiles["activeProfileId"]
+    #
+    #     if minimumChargeLevel is not None:
+    #         minimumChargeLevel = min(max(int(minimumChargeLevel), 25), 100)
+    #         chargingprofileslist
+    #         for i, item in enumerate(chargingprofileslist):
+    #             if profileId == item["id"]:
+    #                 item["minSoc"] = minimumChargeLevel
+    #                 chargingprofileslist[i] = item
+    #
+    #     return await self._updateChargingProfile(vin, chargingprofileslist)
 
-        if profileId is None:
-            profileId = chargingprofiles["activeProfileId"]
-
-        if minimumChargeLevel is not None:
-            minimumChargeLevel = min(max(int(minimumChargeLevel), 25), 100)
-            chargingprofileslist
-            for i, item in enumerate(chargingprofileslist):
-                if profileId == item["id"]:
-                    item["minSoc"] = minimumChargeLevel
-                    chargingprofileslist[i] = item
-
-        return await self._updateChargingProfile(vin, chargingprofileslist)
-
-    async def _updateChargingProfile(
-        self,
-        vin,
-        chargingprofileslist,
-    ):
-        profile = {
-            "key": "CHARGING_PROFILES_EDIT",
-            "payload": {"list": chargingprofileslist},
-        }
-        _LOGGER.debug(f"Updating charging profile for {vin}")
-
-        result = await self._connection.post(
-            f"/connect/v1/vehicles/{vin}/commands",
-            json=profile,
-        )
-
-        _LOGGER.debug(result)
-
-        return result
+    # async def _updateChargingProfile(
+    #     self,
+    #     vin,
+    #     chargingprofileslist,
+    # ):
+    #     profile = {
+    #         "key": "CHARGING_PROFILES_EDIT",
+    #         "payload": {"list": chargingprofileslist},
+    #     }
+    #     _LOGGER.debug(f"Updating charging profile for {vin}")
+    #
+    #     result = await self._connection.post(
+    #         f"/connect/v1/vehicles/{vin}/commands",
+    #         json=profile,
+    #     )
+    #
+    #     _LOGGER.debug(result)
+    #
+    #     return result


### PR DESCRIPTION
Since this got a bit bigger than i initially expected, here's a PR ;)

There is one thing we need to consider, for HA usage, they want to pass their own instance of httpx.AsyncClient to the library, to avoid blocking the main loop (for ssl init) and connection pooling.

https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/inject-websession

The drawback is that we can't create our own AsyncClient with default headers and timeout.
So i had to modify both connection and oauth2 so that they send the headers and timeout without relyying on the connection defaults.

In HA, a connection needs to be created with the httpx.AsyncClient provided by HA, and then it can be passed to the PorscheConnectAccount init function.

I also fixed most of the typing warnings.

I also commented out the _update_data_for_vehicle call in _init_vehicles, that way we don't have to fetch data for all vehicles if you're only interested in one. For HA use, does that make sense?

I suppose we should now be able to remove client.py :)
