### PR TITLE
fix(oauth2): resolve resume URL with urljoin to support absolute Location headers

### DIFF
--- a/pyporscheconnectapi/oauth2.py
+++ b/pyporscheconnectapi/oauth2.py
@@ -9,7 +9,7 @@ import logging
 import re
 import time
 from typing import NamedTuple
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -175,7 +175,7 @@ class OAuth2Client:
 
                 # completed the Identifier First flow, now resume the auth code request
                 params = await self.get_and_extract_location_params(
-                    f"https://{AUTHORIZATION_SERVER}{resume_path}",
+                    urljoin(f"https://{AUTHORIZATION_SERVER}", resume_path),
                 )
                 authorization_code = params.get("code", [None])[0]
 
@@ -190,7 +190,7 @@ class OAuth2Client:
             try:
                 resume_path = await self.login_with_identifier(self.captcha.state)
                 params = await self.get_and_extract_location_params(
-                    f"https://{AUTHORIZATION_SERVER}{resume_path}",
+                    urljoin(f"https://{AUTHORIZATION_SERVER}", resume_path),
                 )
                 authorization_code = params.get("code", [None])[0]
 


### PR DESCRIPTION
## Problem

`login_with_identifier` returns whatever the `/u/login/password` endpoint puts in its `Location` header. In some account states this is an **absolute URL** (e.g. `https://my.porsche.com/?iss=https%3A%2F%2Fidentity.porsche.com%2F`) rather than a relative path (`/authorize/resume?state=...`).

The existing code concatenates with an f-string:

```python
resume_path = await self.login_with_identifier(...)
params = await self.get_and_extract_location_params(
    f"https://{AUTHORIZATION_SERVER}{resume_path}",
)
```

When `resume_path` is already absolute, this yields `https://identity.porsche.comhttps://my.porsche.com/...` and fails with an opaque DNS error:

```
httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known
```

## Repro

Hit when authenticating a Porsche ID account where the password step redirects directly to a `my.porsche.com` page rather than `/authorize/resume`. Debug log:

```
oauth2: Submitting e-mail address and captcha code to auth endpoint.
oauth2: Submitting password to auth endpoint.
oauth2: Resume at https://my.porsche.com/?iss=https%3A%2F%2Fidentity.porsche.com%2F:
ConnectError: [Errno 8] nodename nor servname provided, or not known
```

## Fix

Replace the f-string with `urllib.parse.urljoin()`. Per RFC 3986, `urljoin()` returns the second argument unchanged if absolute, and resolves relative paths against la base otherwise — same call site works in both cases.

Verified:

| `resume_path` | `urljoin` result |
|---|---|
| `/authorize/resume?state=abc` | `https://identity.porsche.com/authorize/resume?state=abc` |
| `authorize/resume?state=abc` | `https://identity.porsche.com/authorize/resume?state=abc` |
| `https://my.porsche.com/?iss=...` | `https://my.porsche.com/?iss=...` |

Applied to both branches in `fetch_authorization_code` (captcha-required and non-captcha). 3-line diff. No behaviour change for the relative-path case. Ruff (`ALL`) clean.