### PR TITLE
test: bootstrap OAuth2 suite with respx + pytest-asyncio (6 tests)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,9 @@ ignore = [ "ANN", "PLR2004", "PLR0912", "PLR0913", "TC001", "C901", "B008", "D20
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*.py" = [ "INP001", "T201" ]
+"tests/*.py" = [ "INP001", "S101", "D", "ARG001", "S105", "S106" ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,4 @@
 httpx
+pytest
+pytest-asyncio
+respx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared pytest fixtures."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from pyporscheconnectapi.connection import Connection
+
+
+@pytest.fixture
+def email() -> str:
+    return "user@example.com"
+
+
+@pytest.fixture
+def password() -> str:
+    return "s3cret"
+
+
+@pytest.fixture
+async def connection(email: str, password: str):
+    """An unauthenticated Connection sharing a single httpx.AsyncClient.
+
+    The shared client lets respx intercept every HTTP call made by the lib
+    in the test, and lets the OAuth flow keep its cookies across requests.
+    """
+    async with httpx.AsyncClient() as client:
+        conn = Connection(email=email, password=password, async_client=client)
+        try:
+            yield conn
+        finally:
+            await conn.close()

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -1,0 +1,192 @@
+"""OAuth2 flow tests against a respx-mocked Porsche identity server."""
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+import respx
+
+from pyporscheconnectapi.connection import Connection
+from pyporscheconnectapi.const import (
+    AUTHORIZATION_SERVER,
+    REDIRECT_URI,
+)
+from pyporscheconnectapi.exceptions import (
+    PorscheCaptchaRequiredError,
+    PorscheWrongCredentialsError,
+)
+from pyporscheconnectapi.oauth2 import Captcha
+
+# A minimal SVG payload — the wire format the lib emits in
+# `PorscheCaptchaRequiredError.captcha`.
+SAMPLE_SVG = b'<svg xmlns="http://www.w3.org/2000/svg" width="150" height="50"/>'
+SAMPLE_CAPTCHA_DATA_URI = (
+    "data:image/svg+xml;base64," + base64.b64encode(SAMPLE_SVG).decode()
+)
+SAMPLE_HTML_WITH_CAPTCHA = (
+    '<html><body><div class="captcha"><img alt="captcha" '
+    f'src="{SAMPLE_CAPTCHA_DATA_URI}"/></div></body></html>'
+)
+
+TOKEN_PAYLOAD = {
+    "access_token": "fake.access.token",
+    "refresh_token": "fake.refresh.token",
+    "expires_in": 3600,
+    "token_type": "Bearer",
+}
+
+
+def _redirect(location: str, status: int = 302) -> httpx.Response:
+    return httpx.Response(status, headers={"Location": location})
+
+
+@pytest.fixture
+def routes():
+    """Reset respx for every test, intercepting only Porsche identity hosts."""
+    with respx.mock(
+        base_url=f"https://{AUTHORIZATION_SERVER}", assert_all_called=False,
+    ) as router:
+        yield router
+
+
+@pytest.mark.asyncio
+async def test_existing_auth0_session_returns_code_directly(
+    connection: Connection, routes,
+):
+    """When /authorize already has a session, no identifier flow runs."""
+    routes.get("/authorize").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?code=AUTHCODE&state=STATE"),
+    )
+    routes.post("/oauth/token").mock(
+        return_value=httpx.Response(200, json=TOKEN_PAYLOAD),
+    )
+
+    await connection.get_token()
+    assert connection.token["access_token"] == "fake.access.token"
+
+    # identifier-first endpoints must NOT have been called
+    assert not any(
+        call.request.url.path.startswith("/u/login/")
+        for call in routes.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_identifier_first_flow_with_relative_resume_path(
+    connection: Connection, routes,
+):
+    """Full happy path: no session → identifier → password → resume → code."""
+    routes.get("/authorize").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?state=ST"),
+    )
+    routes.post("/u/login/identifier").mock(
+        return_value=httpx.Response(200),
+    )
+    routes.post("/u/login/password").mock(
+        return_value=_redirect("/authorize/resume?state=ST"),
+    )
+    routes.get("/authorize/resume").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?code=AUTHCODE&state=ST"),
+    )
+    routes.post("/oauth/token").mock(
+        return_value=httpx.Response(200, json=TOKEN_PAYLOAD),
+    )
+
+    await connection.get_token()
+    assert connection.token["refresh_token"] == "fake.refresh.token"
+
+
+@pytest.mark.asyncio
+async def test_captcha_required_raises_with_payload_and_state(
+    connection: Connection, routes,
+):
+    """A 400 on /u/login/identifier with a captcha SVG bubbles up cleanly."""
+    routes.get("/authorize").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?state=ST"),
+    )
+    routes.post("/u/login/identifier").mock(
+        return_value=httpx.Response(400, text=SAMPLE_HTML_WITH_CAPTCHA),
+    )
+
+    with pytest.raises(PorscheCaptchaRequiredError) as exc_info:
+        await connection.get_token()
+
+    err = exc_info.value
+    assert err.state == "ST"
+    assert err.captcha == SAMPLE_CAPTCHA_DATA_URI
+
+
+@pytest.mark.asyncio
+async def test_wrong_password_raises(connection: Connection, routes):
+    """A 400 on /u/login/password is reported as PorscheWrongCredentialsError."""
+    routes.get("/authorize").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?state=ST"),
+    )
+    routes.post("/u/login/identifier").mock(
+        return_value=httpx.Response(200),
+    )
+    routes.post("/u/login/password").mock(
+        return_value=httpx.Response(400),
+    )
+
+    with pytest.raises(PorscheWrongCredentialsError):
+        await connection.get_token()
+
+
+@pytest.mark.asyncio
+async def test_wrong_email_raises(connection: Connection, routes):
+    """A 401 on /u/login/identifier is reported as PorscheWrongCredentialsError."""
+    routes.get("/authorize").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?state=ST"),
+    )
+    routes.post("/u/login/identifier").mock(
+        return_value=httpx.Response(401),
+    )
+
+    with pytest.raises(PorscheWrongCredentialsError):
+        await connection.get_token()
+
+
+@pytest.mark.asyncio
+async def test_captcha_retry_completes_login(connection: Connection, routes):
+    """After a captcha challenge, setting captcha_code on the same Connection
+    and retrying get_token() must complete the flow without re-running /authorize.
+
+    This guards the path the HA integration uses: captch error → user reads code
+    → caller mutates oauth2_client.captcha → caller retries.
+    """
+    # First call triggers the captcha (responds to /authorize then /u/login/identifier).
+    routes.get("/authorize").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?state=ST"),
+    )
+    identifier_route = routes.post("/u/login/identifier")
+    identifier_route.mock(
+        side_effect=[
+            httpx.Response(400, text=SAMPLE_HTML_WITH_CAPTCHA),  # first call → captcha
+            httpx.Response(200),  # retry with captcha_code → OK
+        ],
+    )
+    routes.post("/u/login/password").mock(
+        return_value=_redirect("/authorize/resume?state=ST"),
+    )
+    routes.get("/authorize/resume").mock(
+        return_value=_redirect(f"{REDIRECT_URI}?code=AUTHCODE&state=ST"),
+    )
+    routes.post("/oauth/token").mock(
+        return_value=httpx.Response(200, json=TOKEN_PAYLOAD),
+    )
+
+    with pytest.raises(PorscheCaptchaRequiredError) as exc_info:
+        await connection.get_token()
+
+    state = exc_info.value.state
+    connection.oauth2_client.captcha = Captcha(captcha_code="ABC123", state=state)
+
+    await connection.get_token()
+    assert connection.token["access_token"] == "fake.access.token"
+
+    # The identifier endpoint was hit twice — once without captcha, once with.
+    assert identifier_route.call_count == 2
+    last_body = identifier_route.calls[-1].request.content.decode()
+    assert "captcha=ABC123" in last_body


### PR DESCRIPTION
## Why

The repo currently has no `tests/` directory and `requirements_dev.txt` only contains `httpx`. Every change ships untested.

A trivial unit test on `fetch_authorization_code` would have caught the URL-concat bug fixed in #PR1.

## What

Adds a minimal baseline que runs entirely offline against a respx-mocked Porsche identity server.

| Test | Path under test |
|---|---|
| `test_existing_auth0_session_returns_code_directly` | `/authorize` returns code → identifier flow is skipped |
| `test_identifier_first_flow_with_relative_resume_path` | Full happy path: no session → identifier → password → resume → code |
| `test_captcha_required_raises_with_payload_and_state` | 400 with captcha SVG → `PorscheCaptchaRequiredError` |
| `test_wrong_password_raises` | 400 on `/u/login/password` → `PorscheWrongCredentialsError` |
| `test_wrong_email_raises` | 401 on `/u/login/identifier` → `PorscheWrongCredentialsError` |
| `test_captcha_retry_completes_login` | After captcha, mutating `oauth2_client.captcha` + retrying `get_token()` completes — guards the captcha-retry pattern callers (HA integration, CLI) rely on |

## Infra

- `pytest`, `pytest-asyncio`, `respx` added to `requirements_dev.txt`
- `[tool.pytest.ini_options]` in `pyproject.toml`: asyncio auto mode, function-scoped fixture loop
- ruff relaxed for `tests/` (asserts, missing docstrings, hard-coded test "passwords") — production code still on `ALL`

## Verified

```
$ pytest tests/ -q
......                                                                   [100%]
6 passed in 5.09s

$ ruff check tests/ pyporscheconnectapi/
All checks passed!
```

## Follow-ups

This is intentionally minimal — gets a foundation in. Easy adds once this lands:
- `test_vehicle.py` covering `get_stored_overview` payload parsing
- Coverage for the `urljoin` fix in PR1 (depends on that PR)
- CI (GitHub Actions) running pytest + ruff on every push